### PR TITLE
Update to Agda 2.6.0.1

### DIFF
--- a/hakyll-agda.cabal
+++ b/hakyll-agda.cabal
@@ -21,7 +21,7 @@ source-repository head
 
 Library
     Build-Depends:    base         >= 3 && < 5
-                    , Agda         == 2.5.*
+                    , Agda         == 2.6.*
                     , containers
                     , directory
                     , filepath

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,14 @@
 packages:
 - '.'
 extra-deps:
-- Agda-2.5.4.2
-- hakyll-4.12.4.0
-resolver: lts-12.26
+- Agda-2.6.0.1
+- hakyll-4.13.0.1
+- EdisonCore-1.3.2.1
+- data-hash-0.2.0.1
+- equivalence-0.3.5
+- geniplate-mirror-0.7.6
+- lrucache-1.2.0.1
+- EdisonAPI-1.3.1
+- STMonadTrans-0.4.4
+resolver: lts-13.21
 


### PR DESCRIPTION
This PR updates hakyll-agda to work with Agda 2.6.0.1. I've only fixed type errors resulting from Agda API changes, but in my very limited tests, everything still seems to work.