### PR TITLE
Update to Agda 2.6.1

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,9 @@
 packages:
-- '.'
+  - '.'
 extra-deps:
-- Agda-2.6.0.1
-- hakyll-4.13.0.1
-- EdisonCore-1.3.2.1
-- data-hash-0.2.0.1
-- equivalence-0.3.5
-- geniplate-mirror-0.7.6
-- lrucache-1.2.0.1
-- EdisonAPI-1.3.1
-- STMonadTrans-0.4.4
-resolver: lts-13.21
-
+  - Agda-2.6.1
+  - data-hash-0.2.0.1
+  - equivalence-0.3.5
+  - geniplate-mirror-0.7.7
+  - STMonadTrans-0.4.4
+resolver: lts-16.0


### PR DESCRIPTION
Switch to Stackage LTS 16.0 (GHC 8.8.3) with Agda 2.6.1. Minimal breakage due to Agda API changes.